### PR TITLE
Fix routing issues with subpages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 yew-router = { version = "0.18" }
-yew-bootstrap = "0.10"
+yew-bootstrap = "0.11"
 gloo-net = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen-futures = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,38 @@ fn my_nav_bar() -> Html {
             height: String::from("80"),
         }),
     };
+    let navigator = use_navigator().unwrap();
+
+    let about = {
+        let navigator = navigator.clone();
+        let onclick = Callback::from(move |_| navigator.push(&Route::About));
+        html! {
+            <NavItem text="About" {onclick} />
+        }
+    };
+
+    let yew_tutorial = {
+        let navigator = navigator.clone();
+        let onclick = Callback::from(move |_| navigator.push(&Route::YewTutorial));
+        html! {
+            <NavDropdownItem text="Yew Tutorial" {onclick} />
+        }
+    };
+
+    let manim_rs = {
+        let navigator = navigator.clone();
+        let onclick = Callback::from(move |_| navigator.push(&Route::Manim));
+        html! {
+            <NavDropdownItem text="manim-rs" {onclick} />
+        }
+    };
+
     html! {
         <NavBar nav_id={"navbar"} class="navbar-expand-lg navbar-light bg-light" brand={brand}>
-            <NavItem text="About" url={AttrValue::from("/about")} />
+            {about}
             <NavItem text="Projects">
-                <NavDropdownItem text="Yew Tutorial" url={AttrValue::from("/projects/yew_tutorial")} />
-                <NavDropdownItem text="manim-rs" url={AttrValue::from("/projects/manim-rs")} />
+                {yew_tutorial}
+                {manim_rs}
             </NavItem>
         </NavBar>
     }
@@ -61,8 +87,8 @@ fn app() -> Html {
     html! {
         <>
         {include_inline()}
-        <MyNavBar/>
         <BrowserRouter>
+            <MyNavBar/>
             <Switch<Route> render={switch} />
         </BrowserRouter>
         {include_cdn_js()}


### PR DESCRIPTION
The NavItem "url" attribute causes the browser to make a new request for the named page.  Our website is (currently) set up as a Single Page Application (SPA) using the Yew router, and can't support direct server requests for the subpages*.  In order to have the WASM application handle the request, the "onclick" attribute has to be used instead.

*unless the server is explicitly configured to serve index.html for unrecognized paths, which we can't do for GitHub Pages

References:
- https://yew.rs/docs/concepts/router
- https://yew.rs/docs/concepts/router#navigation
- https://yew.rs/docs/more/deployment#serving-indexhtml-as-a-fallback

There were two additional details that needed to be fixed:
- NavDropdownItemProps did not support the onclick attribute until yew-bootstrap version 0.11
- The MyNavBar component needed to be placed beneath the BrowserRouter node in order to enable use of the navigator API.

Tested using Apache as a static web server.  Attempts to navigate with the navbar items from the existing code returned 404 errors.  The same attempts to navigate with the code from this commit correctly return the appropriate page content.

There is one remaining issue.  Switching from the "url" attribute to the "onclick" attribute has caused the cursor shape on mouseover to change: it is now a text selection icon rather than the typical hand icon.  This is a poor behavior for UX and needs to be fixed.